### PR TITLE
h3, list, h3 interpreted as faulty meta data

### DIFF
--- a/test/out-expected/moremarked.html
+++ b/test/out-expected/moremarked.html
@@ -1,0 +1,15 @@
+<h3 id="header-3">header 3</h3>
+<ul>
+<li>item 1</li>
+<li>item 2</li>
+<li>item 3</li>
+<li>item 4</li>
+<li>item 5</li>
+</ul>
+<h3 id="another-header-3">another header 3</h3>
+<ul>
+<li>item 1</li>
+<li>item 2</li>
+<li>item 3</li>
+<li>item 4</li>
+</ul>

--- a/test/src/documents/moremarked.html.md
+++ b/test/src/documents/moremarked.html.md
@@ -1,0 +1,14 @@
+### header 3
+
+- item 1
+- item 2
+- item 3
+- item 4
+- item 5
+
+### another header 3
+
+- item 1
+- item 2
+- item 3
+- item 4


### PR DESCRIPTION
minimized an error in my project to this example. something doesn't seem right as it fails silently and doesn't generate any ./out directory at all. i feel like i'm missing something as wtf.

```
npm test

> docpad-plugin-marked@2.2.0 test /home/michael/repos/docpad/docpad-plugin-marked
> node ./out/marked.test.js

marked
marked ➞  create
marked ➞  create ✔   
marked ➞  load plugin marked
marked ➞  load plugin marked ✔   
marked ➞  generate
marked ➞  generate ➞  action
marked ➞  generate ➞  action ✔   
marked ➞  generate ➞  results
marked ➞  generate ➞  results ✘  
marked ➞  generate ✘  
marked ✘  

FAILURE: 3/3 tests ran successfully; 0 failed, 0 incomplete, 1 errors

Error #1:
marked ➞  generate ➞  results
Error: ENOENT, readdir '/home/michael/repos/docpad/docpad-plugin-marked/test/out'

npm ERR! Test failed.  See above for more details.
npm ERR! not ok code 0
```

yet

```
node                
> console.log(require('marked')(fs.readFileSync('./test/src/documents/moremarked.html.md').toString()))
<h3 id="header-3">header 3</h3>
<ul>
<li>item 1</li>
<li>item 2</li>
<li>item 3</li>
<li>item 4</li>
<li>item 5</li>
</ul>
<h3 id="another-header-3">another header 3</h3>
<ul>
<li>item 1</li>
<li>item 2</li>
<li>item 3</li>
<li>item 4</li>
</ul>
```
