### PR TITLE
fix(render): use async form of marked

### DIFF
--- a/src/marked.plugin.coffee
+++ b/src/marked.plugin.coffee
@@ -26,7 +26,11 @@ module.exports = (BasePlugin) ->
 				marked.setOptions(config.markedOptions)
 
 				# Render
-				opts.content = marked(opts.content)
+				# use async form of marked in case highlight function requires it
+				marked opts.content, (err, result) ->
+					opts.content = result
+					next(err)
 
-			# Done
-			next()
+			else
+				# Done
+				next()


### PR DESCRIPTION
Always use the asynchronous form of the marked function in case
an asynchronous highlight function is required.

This allows use of pygments.
